### PR TITLE
Not aveilable getMockBuilder  on php7.4

### DIFF
--- a/tests/PayjpTest.php
+++ b/tests/PayjpTest.php
@@ -8,7 +8,7 @@ class PayjpTest extends TestCase
     {
         $msg1 = 'test1';
         $msg2 = 'test2';
-        $mock = $this->getMockBuilder('\Payjp\Logger\LoggerInterface')->getMock();
+        $mock = $this->mock = $this->getMock('\Payjp\HttpClient\ClientInterface');
         $mock->method('info')->with($msg1);
         $mock->method('error')->with($msg2);
         Payjp::setLogger($mock);


### PR DESCRIPTION
- Fix CI fail https://travis-ci.org/github/payjp/payjp-php/jobs/733169464

```
1) Payjp\PayjpTest::testLogger
Function ReflectionType::__toString() is deprecated
/home/travis/build/payjp/payjp-php/tests/PayjpTest.php:11
```