### PR TITLE
php8.2非推奨コードの修正

### DIFF
--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -54,7 +54,7 @@ abstract class ApiResource extends PayjpObject
     public static function classUrl()
     {
         $base = static::className();
-        return "/v1/${base}s";
+        return "/v1/{$base}s";
     }
 
     /**

--- a/lib/Error/Base.php
+++ b/lib/Error/Base.php
@@ -6,6 +6,10 @@ use Exception;
 
 abstract class Base extends Exception
 {
+    public $httpStatus;
+    public $httpBody;
+    public $jsonBody;
+
     public function __construct(
         $message,
         $httpStatus = null,

--- a/lib/Error/Card.php
+++ b/lib/Error/Card.php
@@ -4,6 +4,8 @@ namespace Payjp\Error;
 
 class Card extends Base
 {
+    public $param;
+
     public function __construct(
         $message,
         $param,

--- a/lib/Error/InvalidRequest.php
+++ b/lib/Error/InvalidRequest.php
@@ -4,6 +4,8 @@ namespace Payjp\Error;
 
 class InvalidRequest extends Base
 {
+    public $param;
+
     public function __construct(
         $message,
         $param,

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -104,7 +104,11 @@ abstract class Util
     public static function utf8($value)
     {
         if (is_string($value) && mb_detect_encoding($value, "UTF-8", true) != "UTF-8") {
-            return utf8_encode($value);
+            if (\PHP_VERSION_ID >= 80200) {
+                return mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1');
+            } else {
+                return utf8_encode($value);
+            }
         } else {
             return $value;
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
     protected $mock;
 
+    public $call;
+
     protected static function authorizeFromEnv()
     {
         $apiKey = getenv('PAYJP_API_KEY');


### PR DESCRIPTION
パッケージをPHP8.2環境で使用していたところいくつかPHP8.2で非推奨となったコードがあったため、動作しませんでした。
PHPStanによる静的解析、自動テストと弊社環境による動的解析の3つを併用してPHP8.2環境で動作しないコードの修正をさせていただきましたのでご確認をお願いいたします。

具体的に衝突したエラーは後述しますが、PHP8.2環境で動作しないコードの根拠は以下を参照しています。
https://www.php.net/manual/ja/migration82.incompatible.php
https://www.php.net/manual/ja/migration82.deprecated.php

内容の性質上、PHPStanなどの静的解析によるバージョン互換性チェックでは網羅的にチェックできませんでした。
動的解析によるチェックは必要でしたが、既存のテストコードによる網羅率はステートメントカバレッジで75％程度であったため、このPRの内容でPHP8.2で完全に動作する保証は得られません。少なくとも弊社PHP8.2環境上では動作した、程度の修正内容にとどまります。

具体的に対応したエラーは以下の通りとなります。

## 衝突したPHP8.2非推奨エラー
- 動的なプロパティ宣言が非推奨となった
  - https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties
- `"${var}"` スタイルの変数展開が非推奨となった
  - https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.relative-callables
- `unf8_encode()` が非推奨となった
  - https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.standard