### PR TITLE
for #36 : php8.2 deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,20 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 4
       matrix:
-        version: [ '5.6', '7.1', '7.2', '7.3', '7.4',  'latest']
+        version: [
+          '5.6',
+          '7.0',
+          '7.1',
+          '7.2',
+          '7.3',
+          '7.4',
+          '8.0',
+          '8.1',
+          '8.2',
+          'latest'
+        ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up PHP
@@ -16,4 +28,4 @@ jobs:
         with:
           php-version: ${{ matrix.version }}
       - name: Execute Test
-        run: MAX_RETRY=2 ./build.php 1
+        run: MAX_RETRY=3 ./build.php 1

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -54,7 +54,7 @@ abstract class ApiResource extends PayjpObject
     public static function classUrl()
     {
         $base = static::className();
-        return "/v1/${base}s";
+        return "/v1/{$base}s";
     }
 
     /**

--- a/lib/Error/Base.php
+++ b/lib/Error/Base.php
@@ -6,6 +6,10 @@ use Exception;
 
 abstract class Base extends Exception
 {
+    public $httpStatus;
+    public $httpBody;
+    public $jsonBody;
+
     public function __construct(
         $message,
         $httpStatus = null,

--- a/lib/Error/Card.php
+++ b/lib/Error/Card.php
@@ -4,6 +4,8 @@ namespace Payjp\Error;
 
 class Card extends Base
 {
+    public $param;
+
     public function __construct(
         $message,
         $param,

--- a/lib/Error/InvalidRequest.php
+++ b/lib/Error/InvalidRequest.php
@@ -4,6 +4,8 @@ namespace Payjp\Error;
 
 class InvalidRequest extends Base
 {
+    public $param;
+
     public function __construct(
         $message,
         $param,

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -104,7 +104,11 @@ abstract class Util
     public static function utf8($value)
     {
         if (is_string($value) && mb_detect_encoding($value, "UTF-8", true) != "UTF-8") {
-            return utf8_encode($value);
+            if (\PHP_VERSION_ID >= 80200) {
+                return mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1');
+            } else {
+                return utf8_encode($value);
+            }
         } else {
             return $value;
         }

--- a/scenario/ChargeForPlatform.php
+++ b/scenario/ChargeForPlatform.php
@@ -51,26 +51,18 @@ $chargeParams = array(
     "platform_fee" => null,
     "tenant" => $tenantId
 );
-$ch = \Payjp\Charge::create($chargeParams);
+$ch = null;
 try {
-    assert($ch->total_platform_fee > 0, 'Can charge');
+    $ch = \Payjp\Charge::create($chargeParams);
+    assert($ch["total_platform_fee"] > 0, 'Invalid charge');
 } catch (Exception $e) {
-    $ch->refund();
-    assert(false, 'Can charge');
+    if ($ch !== null) {
+        $ch->refund();
+    }
+    assert(false, 'Cannot charge');
 }
-assert($ch->refund()->refunded, 'Can refund');
-
-$chargeParams['platform_fee'] = 0;
-$ch = \Payjp\Charge::create($chargeParams);
-try {
-    assert($ch->total_platform_fee === $chargeParams['platform_fee'], 'Can charge');
-} catch (Exception $e) {
-    $ch->refund();
-    assert(false, 'Can charge');
-}
-assert($ch->refund()->refunded, 'Can refund');
-
-$ch = \Payjp\Charge::all(array("tenant" => $ch->tenant));
-assert(count($ch->data) >= 2, 'Can charge'); // todo 事前にcountをみて正確なassertに
+assert($ch->refund()->refunded, 'Cannot refund');
+$chs = \Payjp\Charge::all(array("tenant" => $tenantId));
+assert($chs->count > 0, 'Invalid charge count');
 
 cleanup();

--- a/scenario/README.md
+++ b/scenario/README.md
@@ -9,6 +9,7 @@ php scenario/TenantForPlatform.php
 
 $PAYJP_API_KEY=<your_sk_key> \
 TENANT_ID=<your_tenant_id> \
+CUSTOMER_ID=<your_tenant_id> \
 php scenario/ChargeForPlatform.php
 
 $PAYJP_API_KEY=<your_sk_key> \

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
     protected $mock;
 
+    public $call;
+
     protected static function authorizeFromEnv()
     {
         $apiKey = getenv('PAYJP_API_KEY');


### PR DESCRIPTION
- https://github.com/payjp/payjp-php/pull/36 をサポートバージョンでのテスト込みでリリース
    - および`scenario/`以下の実行
- 各サポートバージョンをCI対象に
    - https://github.com/payjp/payjp-php/actions/runs/5207874415
    - ただし並列実行数が増えると、単体テストでmock移行できてないものがrate limitで落ちる。並列実行数を制限しつつリトライ回数も増やした。
    - あくまで暫定対応。根本的にはrate limitの例外補足、ないしはmock化を進めたい。