### PR TITLE
test: Updated some deprecated methods for phpunit 10.

### DIFF
--- a/tests/ApiRequestorTest.php
+++ b/tests/ApiRequestorTest.php
@@ -44,12 +44,16 @@ class ApiRequestorTest extends TestCase
 
     private function setUpResponses($responses)
     {
+        $userCallCount = 0;
         $mock = $this->setUpMockRequest();
-        for ($i = 0; $i < count($responses); $i++) {
-            $mock->expects($this->at($i))
+        $mock->expects($this->exactly(count($responses)))
             ->method('request')
-            ->willReturn(array(json_encode($responses[$i]['rbody']), $responses[$i]['rcode']));
-        }
+            // $userCallCount を使って、responses の中から適切なものを選択するために、参照渡しで渡す。
+            ->willReturnCallback(static function () use ($responses, &$userCallCount) {
+                $userCallCount++;
+                $response = $responses[$userCallCount - 1];
+                return array(json_encode($response['rbody']), $response['rcode']);
+            });
     }
 
     // _encodeObjects

--- a/tests/BalanceTest.php
+++ b/tests/BalanceTest.php
@@ -187,8 +187,9 @@ class BalanceTest extends TestCase
     {
         $expectedBalanceId = 'ba_sample1';
         $this->mockRequest('GET', '/v1/balances/' . $expectedBalanceId, array(), $this->balanceResource($expectedBalanceId));
+        $statements = Balance::retrieve($expectedBalanceId);
         $this->mockRequest('POST', '/v1/balances/' . $expectedBalanceId . '/statement_urls', array(), $this->statementUrlResource());
-        $statementUrls = Balance::retrieve($expectedBalanceId)->statementUrls->create();
+        $statementUrls = $statements->statementUrls->create();
         $this->assertSame('statement_url', $statementUrls->object);
         $this->assertTrue($statementUrls->expires > 0);
         $this->assertNotEmpty($statementUrls->url);

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -124,8 +124,9 @@ class StatementTest extends TestCase
     {
         $expectedStatementId = 'st_0d08780a33ab77f1c911a1b7286bd';
         $this->mockRequest('GET', '/v1/statements/' . $expectedStatementId, array(), $this->managedStatementResource($expectedStatementId));
+        $statements = Statement::retrieve($expectedStatementId);
         $this->mockRequest('POST', '/v1/statements/' . $expectedStatementId . '/statement_urls', array(), $this->managedDownloadUrlResource());
-        $statementUrls = Statement::retrieve($expectedStatementId)->statementUrls->create();
+        $statementUrls = $statements->statementUrls->create();
         $this->assertSame('statement_url', $statementUrls->object);
         $this->assertTrue($statementUrls->expires > 0);
         $this->assertNotEmpty($statementUrls->url);

--- a/tests/TenantTransferTest.php
+++ b/tests/TenantTransferTest.php
@@ -60,8 +60,9 @@ class TenantTransferTest extends TestCase
         $expectedTenantId = 'tr_8f0c0fe2c9f8a47f9d18f03959bxx';
         $expectedTenantTransferId = 'ten_tr_23748b8c95c79edff22a8b7b795xx';
         $this->mockRequest('GET', '/v1/tenant_transfers/' . $expectedTenantTransferId, array(), $this->managedTenantTransferResource($expectedTenantId, $expectedTenantTransferId));
+        $statements = TenantTransfer::retrieve($expectedTenantTransferId);
         $this->mockRequest('POST', '/v1/tenant_transfers/' . $expectedTenantTransferId . '/statement_urls', array(), $this->managedDownloadUrlResource());
-        $statementUrls = TenantTransfer::retrieve($expectedTenantTransferId)->statementUrls->create();
+        $statementUrls = $statements->statementUrls->create();
         $this->assertSame('statement_url', $statementUrls->object);
         $this->assertTrue($statementUrls->expires > 0);
         $this->assertNotEmpty($statementUrls->url);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,8 +14,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
     protected $mock;
 
-    public $call;
-
     protected static function authorizeFromEnv()
     {
         $apiKey = getenv('PAYJP_API_KEY');
@@ -42,25 +40,28 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $this->setMaxRetryForCi();
         ApiRequestor::setHttpClient(HttpClient\CurlClient::instance());
         $this->mock = null;
-        $this->call = 0;
     }
 
     protected function mockRequest($method, $path, $params = array(), $return = array('id' => 'myId'))
     {
         $mock = $this->setUpMockRequest();
-        $mock->expects($this->at($this->call++))
-             ->method('request')
-                 ->with(strtolower($method), 'https://api.pay.jp' . $path, $this->anything(), $params, false)
-                 ->willReturn(array(json_encode($return), 200));
+        $mock->expects($this->once())
+            ->method('request')
+            ->with(
+                strtolower($method),
+                'https://api.pay.jp' . $path,
+                $this->anything(),
+                $params,
+                false
+            )
+            ->willReturn(array(json_encode($return), 200));
     }
 
     protected function setUpMockRequest()
     {
-        if (!$this->mock) {
-            self::authorizeFromEnv();
-            $this->mock = $this->createMock('\Payjp\HttpClient\ClientInterface');
-            ApiRequestor::setHttpClient($this->mock);
-        }
+        self::authorizeFromEnv();
+        $this->mock = $this->createMock('\Payjp\HttpClient\ClientInterface');
+        ApiRequestor::setHttpClient($this->mock);
         return $this->mock;
     }
 


### PR DESCRIPTION
## Overview

Updated some deprecated methods for phpunit 10.

* `at()`
* `willReturnOnConsecutiveCalls()` will be removed in phpunit 12, so `willReturnCallback()` is used.
