### PR TITLE
feat: add PHP-CS-Fixer configuration and update composer.json for code style fixes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,7 +5,9 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('vendor')
     ->path('lib')
     ->path('init.php')
-    ->path('build.php');
+    ->path('build.php')
+    ->path('tests')
+    ->path('.php-cs-fixer.php');
 
 $config = new PhpCsFixer\Config();
 return $config->setRules([
@@ -13,5 +15,7 @@ return $config->setRules([
         'strict_param' => true,
         'array_syntax' => ['syntax' => 'short'],
         'no_unused_imports' => true,
+        // Don't force public keyword for const (for compatibility with PHP < 7.1)
+        'visibility_required' => ['elements' => ['property', 'method']],
     ])
     ->setFinder($finder);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,17 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('vendor')
+    ->path('lib')
+    ->path('init.php')
+    ->path('build.php');
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+        '@PSR12' => true,
+        'strict_param' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+    ])
+    ->setFinder($finder);

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 PHP 5.6 and later.
 
 > Even if it is not a corresponding version, it may work, but it does not support it.
-  Due to the PHP [END OF LIFE](http://php.net/supported-versions.php) cycle. 
+  Due to the PHP [END OF LIFE](http://php.net/supported-versions.php) cycle.
 
 ## Composer
 
@@ -55,12 +55,12 @@ echo $charge->amount; // 2000
 ## Retry on HTTP Status Code 429
 
 - See [Rate Limit Guideline](https://pay.jp/docs/guideline-rate-limit#2-%E3%83%AA%E3%83%88%E3%83%A9%E3%82%A4)
-- When you exceeded rate-limit, you can retry request by setting `$maxRetry`  
+- When you exceeded rate-limit, you can retry request by setting `$maxRetry`
   like `\Payjp\Payjp::setMaxRetry(3);` .
-- The retry interval base value is `$retryInitialDelay`  
-  Adjust the value like `\Payjp\Payjp::setRetryInitialDelay(4);`  
+- The retry interval base value is `$retryInitialDelay`
+  Adjust the value like `\Payjp\Payjp::setRetryInitialDelay(4);`
   The smaller is shorter.
-- The retry interval calcurating is based on "Exponential backoff with equal jitter" algorithm.  
+- The retry interval calcurating is based on "Exponential backoff with equal jitter" algorithm.
   See https://aws.amazon.com/jp/blogs/architecture/exponential-backoff-and-jitter/
 
 ## Logging
@@ -78,7 +78,9 @@ echo $charge->amount; // 2000
 
 - When you access inaccessible or non-existing property
 
-## Tests
+## Development
+
+### Running Tests
 
 In order to run tests first install [PHPUnit](http://packagist.org/packages/phpunit/phpunit) via [Composer](http://getcomposer.org/):
 
@@ -87,3 +89,17 @@ In order to run tests first install [PHPUnit](http://packagist.org/packages/phpu
 To run the test suite:
 
     ./vendor/bin/phpunit
+
+You can also use Composer to run the tests:
+
+    composer test
+
+This will run both the code style checks (PSR2) and the PHPUnit tests.
+
+### Code Formatting
+
+To format the code according to our standards:
+
+    composer fix
+
+This command requires PHP 7.4 or higher and will automatically fix coding style issues using PHP-CS-Fixer.

--- a/build.php
+++ b/build.php
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+
 chdir(dirname(__FILE__));
 
 $autoload = (int)$argv[1];

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7 || ~9.5",
-    "squizlabs/php_codesniffer": "~3.6",
-    "friendsofphp/php-cs-fixer": "^3.75"
+    "squizlabs/php_codesniffer": "~3.6"
   },
   "autoload": {
     "psr-4": { "Payjp\\" : "lib/" }
@@ -39,7 +38,14 @@
        "phpunit"
      ],
      "fix": [
+       "@php -r \"if (PHP_VERSION_ID < 70400) { echo 'PHP 7.4 or higher is required. Current version: ' . PHP_VERSION . PHP_EOL; exit(1); }\"",
        "PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --allow-risky=yes"
      ]
+  },
+  "config": {
+    "platform-check": false
+  },
+  "suggest": {
+    "friendsofphp/php-cs-fixer": "Required for the fix command (requires PHP >= 7.4)"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7 || ~9.5",
-    "squizlabs/php_codesniffer": "~3.6"
+    "squizlabs/php_codesniffer": "~3.6",
+    "friendsofphp/php-cs-fixer": "^3.75"
   },
   "autoload": {
     "psr-4": { "Payjp\\" : "lib/" }
@@ -36,6 +37,9 @@
      "test": [
        "phpcs --standard=PSR2 -n lib tests *.php",
        "phpunit"
+     ],
+     "fix": [
+       "PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --allow-risky=yes"
      ]
   }
 }

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -12,7 +12,7 @@ class Account extends ApiResource
             return parent::instanceUrl();
         }
     }
-    
+
     /**
      * @param string|null $id
      * @param array|string|null $opts

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -28,7 +28,7 @@ class ApiRequestor
         } elseif ($d === false) {
             return 'false';
         } elseif (is_array($d)) {
-            $res = array();
+            $res = [];
             foreach ($d as $k => $v) {
                 $res[$k] = self::_encodeObjects($v);
             }
@@ -68,10 +68,10 @@ class ApiRequestor
     public function request($method, $url, $params = null, $headers = null)
     {
         if (!$params) {
-            $params = array();
+            $params = [];
         }
         if (!$headers) {
-            $headers = array();
+            $headers = [];
         }
 
         for ($i = 0; $i <= Payjp::getMaxRetry(); $i++) {
@@ -85,7 +85,7 @@ class ApiRequestor
             }
         }
         $resp = $this->_interpretResponse($rbody, $rcode);
-        return array($resp, $myApiKey);
+        return [$resp, $myApiKey];
     }
 
     /**
@@ -145,18 +145,18 @@ class ApiRequestor
         $params = self::_encodeObjects($params);
         $langVersion = phpversion();
         $uname = php_uname();
-        $ua = array(
+        $ua = [
             'bindings_version' => Payjp::VERSION,
             'lang' => 'php',
             'lang_version' => $langVersion,
             'publisher' => 'payjp',
             'uname' => $uname,
-        );
-        $defaultHeaders = array(
+        ];
+        $defaultHeaders = [
             'X-Payjp-Client-User-Agent' => json_encode($ua),
             'User-Agent' => 'Payjp/v1 PhpBindings/' . Payjp::VERSION,
                 'Authorization' => 'Basic ' . base64_encode($myApiKey.':')
-        );
+        ];
         if (Payjp::$apiVersion) {
             $defaultHeaders['Payjp-Version'] = Payjp::$apiVersion;
         }
@@ -178,7 +178,7 @@ class ApiRequestor
         }
 
         $combinedHeaders = array_merge($defaultHeaders, $headers);
-        $rawHeaders = array();
+        $rawHeaders = [];
 
         foreach ($combinedHeaders as $header => $value) {
             $rawHeaders[] = $header . ': ' . $value;
@@ -191,7 +191,7 @@ class ApiRequestor
             $params,
             $hasFile
         );
-        return array($rbody, $rcode, $myApiKey);
+        return [$rbody, $rcode, $myApiKey];
     }
 
     private function _processResourceParam($resource, $hasCurlFile)

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -4,7 +4,7 @@ namespace Payjp;
 
 abstract class ApiResource extends PayjpObject
 {
-    private static $HEADERS_TO_PERSIST = array('Payjp-Account' => true, 'Payjp-Version' => true);
+    private static $HEADERS_TO_PERSIST = ['Payjp-Account' => true, 'Payjp-Version' => true];
 
     /**
      * @return ApiResource The refreshed resource.
@@ -95,7 +95,7 @@ abstract class ApiResource extends PayjpObject
      *
      * @return list(array, RequestOptions)
      */
-    protected function _request($method, $url, $params = array(), $options = null)
+    protected function _request($method, $url, $params = [], $options = null)
     {
         $opts = $this->_opts->merge($options);
         return static::_staticRequest($method, $url, $params, $opts);
@@ -111,7 +111,7 @@ abstract class ApiResource extends PayjpObject
                 unset($opts->headers[$k]);
             }
         }
-        return array($response, $opts);
+        return [$response, $opts];
     }
 
     protected static function _retrieve($id, $options = null)

--- a/lib/Card.php
+++ b/lib/Card.php
@@ -4,5 +4,4 @@ namespace Payjp;
 
 class Card extends ExternalAccount
 {
-
 }

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -45,12 +45,12 @@ class Collection extends ApiResource
         if (isset($url['query'])) {
             // If the URL contains a query param, parse it out into $params so they
             // don't interact weirdly with each other.
-            $query = array();
+            $query = [];
             parse_str($url['query'], $query);
             // PHP 5.2 doesn't support the ?: operator :(
-            $params = array_merge($params ? $params : array(), $query);
+            $params = array_merge($params ? $params : [], $query);
         }
 
-        return array($url['path'], $params);
+        return [$url['path'], $params];
     }
 }

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -12,7 +12,7 @@ class Customer extends ApiResource
                 . "would be: \"Payjp\\Charge::create(array('amount' => 100, "
                 . "'currency' => 'usd', 'card' => array('number' => "
                 . "4242424242424242, 'exp_month' => 5, 'exp_year' => 2015)))\")";
-                    throw new Error\Api($message);
+            throw new Error\Api($message);
         }
     }
     /**
@@ -77,7 +77,7 @@ class Customer extends ApiResource
     public function charges($params = null)
     {
         if (!$params) {
-            $params = array();
+            $params = [];
         }
         $params['customer'] = $this->id;
         $charges = Charge::all($params, $this->_opts);

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -22,7 +22,7 @@ class CurlClient implements ClientInterface
     {
         $curl = curl_init();
         $method = strtolower($method);
-        $opts = array();
+        $opts = [];
         if ($method == 'get') {
             if ($hasFile) {
                 throw new Error\Api(
@@ -89,7 +89,7 @@ class CurlClient implements ClientInterface
 
         $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
-        return array($rbody, $rcode);
+        return [$rbody, $rcode];
     }
 
     /**
@@ -142,7 +142,7 @@ class CurlClient implements ClientInterface
             return $arr;
         }
 
-        $r = array();
+        $r = [];
         foreach ($arr as $k => $v) {
             if (is_null($v)) {
                 continue;

--- a/lib/Logger/DefaultLogger.php
+++ b/lib/Logger/DefaultLogger.php
@@ -4,12 +4,12 @@ namespace Payjp\Logger;
 
 class DefaultLogger implements LoggerInterface
 {
-    public function error($message, array $context = array())
+    public function error($message, array $context = [])
     {
         error_log($message);
     }
 
-    public function info($message, array $context = array())
+    public function info($message, array $context = [])
     {
         // if you need any output, please use \Payjp\Payjp::setLogger
     }

--- a/lib/Logger/LoggerInterface.php
+++ b/lib/Logger/LoggerInterface.php
@@ -15,7 +15,7 @@ interface LoggerInterface
      * @param array $context
      * @return void
      */
-    public function error($message, array $context = array());
+    public function error($message, array $context = []);
 
     /**
      * Interesting events.
@@ -26,5 +26,5 @@ interface LoggerInterface
      * @param array $context
      * @return void
      */
-    public function info($message, array $context = array());
+    public function info($message, array $context = []);
 }

--- a/lib/PayjpObject.php
+++ b/lib/PayjpObject.php
@@ -3,7 +3,6 @@
 namespace Payjp;
 
 use ArrayAccess;
-use InvalidArgumentException;
 
 class PayjpObject implements ArrayAccess
 {
@@ -20,11 +19,11 @@ class PayjpObject implements ArrayAccess
 
     public static function init()
     {
-        self::$permanentAttributes = new Util\Set(array('_opts', 'id'));
-        self::$nestedUpdatableAttributes = new Util\Set(array(
+        self::$permanentAttributes = new Util\Set(['_opts', 'id']);
+        self::$nestedUpdatableAttributes = new Util\Set([
             'summary', 'accounts_enabled', 'merchant',
                         0, 1, 2, 3, 4 // Max 3, but leave the 4th so errors work properly
-        ));
+        ]);
     }
 
     protected $_opts;
@@ -36,11 +35,11 @@ class PayjpObject implements ArrayAccess
     public function __construct($id = null, $opts = null)
     {
         $this->_opts = $opts ? $opts : new Util\RequestOptions();
-        $this->_values = array();
+        $this->_values = [];
         $this->_unsavedValues = new Util\Set();
         $this->_transientValues = new Util\Set();
 
-        $this->_retrieveOptions = array();
+        $this->_retrieveOptions = [];
         if (is_array($id)) {
             foreach ($id as $key => $value) {
                 if ($key != 'id') {
@@ -84,7 +83,7 @@ class PayjpObject implements ArrayAccess
     {
         if (array_key_exists($k, $this->_values)) {
             return $this->_values[$k];
-        } else if ($this->_transientValues->includes($k)) {
+        } elseif ($this->_transientValues->includes($k)) {
             $class = get_class($this);
             $attrs = join(', ', array_keys($this->_values));
             $message = "Payjp Notice: Undefined property of $class instance: $k. "
@@ -197,7 +196,7 @@ class PayjpObject implements ArrayAccess
      */
     public function serializeParameters()
     {
-        $params = array();
+        $params = [];
         if ($this->_unsavedValues) {
             foreach ($this->_unsavedValues->toArray() as $k) {
                 $v = $this->$k;

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -14,7 +14,7 @@ class Subscription extends ApiResource
     {
         return self::_create($params, $options);
     }
-    
+
     /**
      * @param string $id The ID of the subscription to retrieve.
      * @param array|string|null $options
@@ -25,7 +25,7 @@ class Subscription extends ApiResource
     {
         return self::_retrieve($id, $options);
     }
-    
+
     /**
      * @param array|null $params
      * @param array|string|null $options
@@ -36,13 +36,13 @@ class Subscription extends ApiResource
     {
         return self::_all($params, $options);
     }
-    
+
     /**
      * @param array|null $params
      *
      * @return Subscription The deleted subscription.
      */
-    
+
     public function delete($params = null, $opts = null)
     {
         return $this->_delete($params, $opts);
@@ -71,7 +71,7 @@ class Subscription extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
-    
+
     /**
      * @param array|null $params
      * @param array|string|null $options
@@ -85,7 +85,7 @@ class Subscription extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
-    
+
     /**
      * @param array|null $params
      * @param array|string|null $options

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -9,7 +9,7 @@ class RequestOptions
     public $headers;
     public $apiKey;
 
-    public function __construct($key = null, $headers = array())
+    public function __construct($key = null, $headers = [])
     {
         $this->apiKey = $key;
         $this->headers = $headers;
@@ -45,15 +45,15 @@ class RequestOptions
         }
 
         if (is_null($options)) {
-            return new RequestOptions(null, array());
+            return new RequestOptions(null, []);
         }
 
         if (is_string($options)) {
-            return new RequestOptions($options, array());
+            return new RequestOptions($options, []);
         }
 
         if (is_array($options)) {
-            $headers = array();
+            $headers = [];
             $key = null;
             if (array_key_exists('api_key', $options)) {
                 $key = $options['api_key'];

--- a/lib/Util/Set.php
+++ b/lib/Util/Set.php
@@ -9,9 +9,9 @@ class Set implements IteratorAggregate
 {
     private $_elts;
 
-    public function __construct($members = array())
+    public function __construct($members = [])
     {
-        $this->_elts = array();
+        $this->_elts = [];
         foreach ($members as $item) {
             $this->_elts[$item] = true;
         }

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -7,7 +7,7 @@ use Payjp\PayjpObject;
 abstract class Util
 {
     // todo wanna use 'private const' (only PHP >= v7.1.0)
-    private static $types = array(
+    private static $types = [
         'account' => \Payjp\Account::class,
         'application_url' => \Payjp\ApplicationUrl::class,
         'balance' => \Payjp\Balance::class,
@@ -26,7 +26,7 @@ abstract class Util
         'term' => \Payjp\Term::class,
         'transfer' => \Payjp\Transfer::class,
         'three_d_secure_request' => \Payjp\ThreeDSecureRequest::class,
-    );
+    ];
 
     /**
      * Whether the provided array (or other) is a list rather than a dictionary.
@@ -40,7 +40,7 @@ abstract class Util
             return false;
         }
 
-      // TODO: generally incorrect, but it's correct given Payjp's response
+        // TODO: generally incorrect, but it's correct given Payjp's response
         foreach (array_keys($array) as $k) {
             if (!is_numeric($k)) {
                 return false;
@@ -57,7 +57,7 @@ abstract class Util
      */
     public static function convertPayjpObjectToArray($values)
     {
-        $results = array();
+        $results = [];
         foreach ($values as $k => $v) {
             // FIXME: this is an encapsulation violation
             if (is_string($k) && $k[0] == '_') {
@@ -84,7 +84,7 @@ abstract class Util
     public static function convertToPayjpObject($resp, $opts)
     {
         if (self::isList($resp)) {
-            $mapped = array();
+            $mapped = [];
             foreach ($resp as $i) {
                 array_push($mapped, self::convertToPayjpObject($i, $opts));
             }

--- a/tests/ApiRequestorTest.php
+++ b/tests/ApiRequestorTest.php
@@ -28,19 +28,19 @@ class ApiRequestorTest extends TestCase
         Payjp::setRetryMaxDelay(32);
     }
 
-    private $errorResponse = array('rcode'=>500, 'rbody'=>array('error' => array(
+    private $errorResponse = ['rcode' => 500, 'rbody' => ['error' => [
         "code" => "payjp_wrong",
         "message" => "An unexpected error occurred.",
         "status" => 500,
         "type" => "server_error",
-    )));
-    private $rateLimitResponse = array('rcode'=>429, 'rbody'=>array('error' => array(
+    ]]];
+    private $rateLimitResponse = ['rcode' => 429, 'rbody' => ['error' => [
         "code" => "over_capacity",
         "message" => "The service is over capacity. Please try again later.",
         "status" => 429,
         "type" => "client_error",
-    )));
-    private $successResponse = array('rcode'=>200, 'rbody'=>array('data'=>array()));
+    ]]];
+    private $successResponse = ['rcode' => 200, 'rbody' => ['data' => []]];
 
     private function setUpResponses($responses)
     {
@@ -52,7 +52,7 @@ class ApiRequestorTest extends TestCase
             ->willReturnCallback(static function () use ($responses, &$userCallCount) {
                 $userCallCount++;
                 $response = $responses[$userCallCount - 1];
-                return array(json_encode($response['rbody']), $response['rcode']);
+                return [json_encode($response['rbody']), $response['rcode']];
             });
     }
 
@@ -64,26 +64,26 @@ class ApiRequestorTest extends TestCase
         $method = $reflector->getMethod('_encodeObjects');
         $method->setAccessible(true);
 
-        $a = array('customer' => new Customer('abcd'));
+        $a = ['customer' => new Customer('abcd')];
         $enc = $method->invoke(null, $a);
-        $this->assertSame($enc, array('customer' => 'abcd'));
+        $this->assertSame($enc, ['customer' => 'abcd']);
 
         // Preserves UTF-8
-        $v = array('customer' => "☃");
+        $v = ['customer' => "☃"];
         $enc = $method->invoke(null, $v);
         $this->assertSame($enc, $v);
 
         // Encodes latin-1 -> UTF-8
-        $v = array('customer' => "\xe9");
+        $v = ['customer' => "\xe9"];
         $enc = $method->invoke(null, $v);
-        $this->assertSame($enc, array('customer' => "\xc3\xa9"));
+        $this->assertSame($enc, ['customer' => "\xc3\xa9"]);
     }
 
     // request retry
 
     public function testRetryDisabled()
     {
-        $this->setUpResponses(array($this->rateLimitResponse));
+        $this->setUpResponses([$this->rateLimitResponse]);
         $requestor = new ApiRequestor(self::API_KEY);
 
         try {
@@ -96,7 +96,7 @@ class ApiRequestorTest extends TestCase
 
     public function testNoRetry()
     {
-        $this->setUpResponses(array($this->errorResponse));
+        $this->setUpResponses([$this->errorResponse]);
         $requestor = new ApiRequestor(self::API_KEY);
 
         try {
@@ -110,7 +110,7 @@ class ApiRequestorTest extends TestCase
     public function testFullRetryAndSuccess()
     {
         Payjp::setMaxRetry(2);
-        $this->setUpResponses(array($this->rateLimitResponse, $this->rateLimitResponse, $this->successResponse));
+        $this->setUpResponses([$this->rateLimitResponse, $this->rateLimitResponse, $this->successResponse]);
         $requestor = new ApiRequestor(self::API_KEY);
 
         $response = $requestor->request('GET', '/v1/accounts');
@@ -121,7 +121,7 @@ class ApiRequestorTest extends TestCase
     public function testFullRetryAndFailed()
     {
         Payjp::setMaxRetry(2);
-        $this->setUpResponses(array($this->rateLimitResponse, $this->rateLimitResponse, $this->rateLimitResponse));
+        $this->setUpResponses([$this->rateLimitResponse, $this->rateLimitResponse, $this->rateLimitResponse]);
         $requestor = new ApiRequestor(self::API_KEY);
 
         try {

--- a/tests/BalanceTest.php
+++ b/tests/BalanceTest.php
@@ -129,11 +129,11 @@ class BalanceTest extends TestCase
 
     private function statementUrlResource()
     {
-        return array(
+        return [
             'object' => 'statement_url',
             'url' => 'https://pay.jp/_/statements/a845383731564192xxxxxxxxxxxxxxxx',
             'expires' => 1695796301,
-        );
+        ];
     }
 
     public function testRetrieve()
@@ -194,9 +194,9 @@ class BalanceTest extends TestCase
     public function testStatementUrls()
     {
         $expectedBalanceId = 'ba_sample1';
-        $this->mockRequest('GET', '/v1/balances/' . $expectedBalanceId, array(), $this->balanceResource($expectedBalanceId));
+        $this->mockRequest('GET', '/v1/balances/' . $expectedBalanceId, [], $this->balanceResource($expectedBalanceId));
         $statements = Balance::retrieve($expectedBalanceId);
-        $this->mockRequest('POST', '/v1/balances/' . $expectedBalanceId . '/statement_urls', array(), $this->statementUrlResource());
+        $this->mockRequest('POST', '/v1/balances/' . $expectedBalanceId . '/statement_urls', [], $this->statementUrlResource());
         $statementUrls = $statements->statementUrls->create();
         $this->assertSame('statement_url', $statementUrls->object);
         $this->assertTrue($statementUrls->expires > 0);

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -8,30 +8,30 @@ class CurlClientTest extends TestCase
 {
     public function testEncode()
     {
-        $a = array(
+        $a = [
             'my' => 'value',
-            'that' => array('your' => 'example'),
+            'that' => ['your' => 'example'],
             'bar' => 1,
             'baz' => null
-        );
+        ];
 
         $enc = CurlClient::encode($a);
         $this->assertSame('my=value&that%5Byour%5D=example&bar=1', $enc);
 
-        $a = array('that' => array('your' => 'example', 'foo' => null));
+        $a = ['that' => ['your' => 'example', 'foo' => null]];
         $enc = CurlClient::encode($a);
         $this->assertSame('that%5Byour%5D=example', $enc);
 
-        $a = array('that' => 'example', 'foo' => array('bar', 'baz'));
+        $a = ['that' => 'example', 'foo' => ['bar', 'baz']];
         $enc = CurlClient::encode($a);
         $this->assertSame('that=example&foo%5B%5D=bar&foo%5B%5D=baz', $enc);
 
-        $a = array(
+        $a = [
             'my' => 'value',
-            'that' => array('your' => array('cheese', 'whiz', null)),
+            'that' => ['your' => ['cheese', 'whiz', null]],
             'bar' => 1,
             'baz' => null
-        );
+        ];
 
         $enc = CurlClient::encode($a);
         $expected = 'my=value&that%5Byour%5D%5B%5D=cheese'
@@ -39,7 +39,7 @@ class CurlClientTest extends TestCase
         $this->assertSame($expected, $enc);
 
         // Ignores an empty array
-        $enc = CurlClient::encode(array('foo' => array(), 'bar' => 'baz'));
+        $enc = CurlClient::encode(['foo' => [], 'bar' => 'baz']);
         $expected = 'bar=baz';
         $this->assertSame($expected, $enc);
     }

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -11,14 +11,14 @@ class ErrorTest extends TestCase
                 "hello",
                 500,
                 "{'foo':'bar'}",
-                array('foo' => 'bar')
+                ['foo' => 'bar']
             );
             $this->fail("Did not raise error");
         } catch (Error\Api $e) {
             $this->assertSame("hello", $e->getMessage());
             $this->assertSame(500, $e->getHttpStatus());
             $this->assertSame("{'foo':'bar'}", $e->getHttpBody());
-            $this->assertSame(array('foo' => 'bar'), $e->getJsonBody());
+            $this->assertSame(['foo' => 'bar'], $e->getJsonBody());
         }
     }
 }

--- a/tests/PayjpObjectTest.php
+++ b/tests/PayjpObjectTest.php
@@ -38,7 +38,7 @@ class PayjpObjectTest extends TestCase
     {
         $s = new PayjpObject();
         $s->foo = 'a';
-        $this->assertSame($s->keys(), array('foo'));
+        $this->assertSame($s->keys(), ['foo']);
     }
 
     public function testToArray()

--- a/tests/RequestOptionsTest.php
+++ b/tests/RequestOptionsTest.php
@@ -8,66 +8,66 @@ class RequestOptionsTest extends TestCase
     {
         $opts = Util\RequestOptions::parse("foo");
         $this->assertSame("foo", $opts->apiKey);
-        $this->assertSame(array(), $opts->headers);
+        $this->assertSame([], $opts->headers);
     }
 
     public function testNull()
     {
         $opts = Util\RequestOptions::parse(null);
         $this->assertSame(null, $opts->apiKey);
-        $this->assertSame(array(), $opts->headers);
+        $this->assertSame([], $opts->headers);
     }
 
     public function testEmptyArray()
     {
-        $opts = Util\RequestOptions::parse(array());
+        $opts = Util\RequestOptions::parse([]);
         $this->assertSame(null, $opts->apiKey);
-        $this->assertSame(array(), $opts->headers);
+        $this->assertSame([], $opts->headers);
     }
 
     public function testAPIKeyArray()
     {
         $opts = Util\RequestOptions::parse(
-            array(
+            [
                 'api_key' => 'foo',
-            )
+            ]
         );
         $this->assertSame('foo', $opts->apiKey);
-        $this->assertSame(array(), $opts->headers);
+        $this->assertSame([], $opts->headers);
     }
 
     public function testIdempotentKeyArray()
     {
         $opts = Util\RequestOptions::parse(
-            array(
+            [
                 'idempotency_key' => 'foo',
-            )
+            ]
         );
         $this->assertSame(null, $opts->apiKey);
-        $this->assertSame(array('Idempotency-Key' => 'foo'), $opts->headers);
+        $this->assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
     }
 
     public function testLocaleArray()
     {
         $opts = Util\RequestOptions::parse(
-            array(
+            [
                 'locale' => 'ja',
-            )
+            ]
         );
         $this->assertSame(null, $opts->apiKey);
-        $this->assertSame(array('Locale' => 'ja'), $opts->headers);
+        $this->assertSame(['Locale' => 'ja'], $opts->headers);
     }
 
     public function testKeyArray()
     {
         $opts = Util\RequestOptions::parse(
-            array(
+            [
                 'idempotency_key' => 'foo',
                 'api_key' => 'foo'
-            )
+            ]
         );
         $this->assertSame('foo', $opts->apiKey);
-        $this->assertSame(array('Idempotency-Key' => 'foo'), $opts->headers);
+        $this->assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
     }
 
     public function testWrongType()

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -77,11 +77,11 @@ class StatementTest extends TestCase
 
     private function managedDownloadUrlResource()
     {
-        return array(
+        return [
             'object' => 'statement_url',
             'url' => 'https://pay.jp/_/statements/a845383731564192xxxxxxxxxxxxxxxx',
             'expires' => 1695796301,
-        );
+        ];
     }
 
     public function testRetrieve()
@@ -111,8 +111,8 @@ class StatementTest extends TestCase
 
     public function testAll()
     {
-        $expectedStatementIds = array('st_6b7d642291873e7b97e9175d7d6b8', 'st_0d08780a33ab77f1c911a1b7286bd');
-        $this->mockRequest('GET', '/v1/statements', array(), $this->managedStatementResources($expectedStatementIds));
+        $expectedStatementIds = ['st_6b7d642291873e7b97e9175d7d6b8', 'st_0d08780a33ab77f1c911a1b7286bd'];
+        $this->mockRequest('GET', '/v1/statements', [], $this->managedStatementResources($expectedStatementIds));
         $statements = Statement::all();
         $this->assertSame(count($expectedStatementIds), $statements['count']);
         $this->assertCount(count($expectedStatementIds), $statements['data']);
@@ -123,9 +123,9 @@ class StatementTest extends TestCase
     public function testStatementUrls()
     {
         $expectedStatementId = 'st_0d08780a33ab77f1c911a1b7286bd';
-        $this->mockRequest('GET', '/v1/statements/' . $expectedStatementId, array(), $this->managedStatementResource($expectedStatementId));
+        $this->mockRequest('GET', '/v1/statements/' . $expectedStatementId, [], $this->managedStatementResource($expectedStatementId));
         $statements = Statement::retrieve($expectedStatementId);
-        $this->mockRequest('POST', '/v1/statements/' . $expectedStatementId . '/statement_urls', array(), $this->managedDownloadUrlResource());
+        $this->mockRequest('POST', '/v1/statements/' . $expectedStatementId . '/statement_urls', [], $this->managedDownloadUrlResource());
         $statementUrls = $statements->statementUrls->create();
         $this->assertSame('statement_url', $statementUrls->object);
         $this->assertTrue($statementUrls->expires > 0);

--- a/tests/TenantTransferTest.php
+++ b/tests/TenantTransferTest.php
@@ -6,16 +6,16 @@ class TenantTransferTest extends TestCase
 {
     private function managedTenantTransferResource($tenantId, $tenantTransferId)
     {
-        return array(
+        return [
             'amount' => 0,
             'carried_balance' => null,
-            'charges' => array(
+            'charges' => [
                 'count' => 0,
                 'data' => [],
                 'has_more' => false,
                 'object' => 'list',
                 'url' => 'https://api.pay.jp/v1/transfers/' . $tenantId . '/tenant_transfers/' . $tenantTransferId . '/charges',
-            ),
+            ],
             'created' => time(),
             'currency' => 'ja',
             'id' => $tenantTransferId,
@@ -23,7 +23,7 @@ class TenantTransferTest extends TestCase
             'object' => 'tenant_transfer',
             'scheduled_date' => '2015-09-16',
             'status' => 'pending',
-            'summary' => array(
+            'summary' => [
                 'charge_count' => 0,
                 'charge_fee' => 0,
                 'total_platform_fee' => 0,
@@ -33,20 +33,20 @@ class TenantTransferTest extends TestCase
                 'refund_count' => 0,
                 'dispute_amount' => 0,
                 'dispute_count' => 0,
-            ),
+            ],
             'tenant_id' => $tenantId,
             'term_end' => 1439650800,
             'term_start' => 1438354800,
-        );
+        ];
     }
 
     private function managedDownloadUrlResource()
     {
-        return array(
+        return [
             'object' => 'statement_url',
             'url' => 'https://pay.jp/_/statements/a845383731564192xxxxxxxxxxxxxxxx',
             'expires' => 1695796301,
-        );
+        ];
     }
 
     public function testUrl()
@@ -59,9 +59,9 @@ class TenantTransferTest extends TestCase
     {
         $expectedTenantId = 'tr_8f0c0fe2c9f8a47f9d18f03959bxx';
         $expectedTenantTransferId = 'ten_tr_23748b8c95c79edff22a8b7b795xx';
-        $this->mockRequest('GET', '/v1/tenant_transfers/' . $expectedTenantTransferId, array(), $this->managedTenantTransferResource($expectedTenantId, $expectedTenantTransferId));
+        $this->mockRequest('GET', '/v1/tenant_transfers/' . $expectedTenantTransferId, [], $this->managedTenantTransferResource($expectedTenantId, $expectedTenantTransferId));
         $statements = TenantTransfer::retrieve($expectedTenantTransferId);
-        $this->mockRequest('POST', '/v1/tenant_transfers/' . $expectedTenantTransferId . '/statement_urls', array(), $this->managedDownloadUrlResource());
+        $this->mockRequest('POST', '/v1/tenant_transfers/' . $expectedTenantTransferId . '/statement_urls', [], $this->managedDownloadUrlResource());
         $statementUrls = $statements->statementUrls->create();
         $this->assertSame('statement_url', $statementUrls->object);
         $this->assertTrue($statementUrls->expires > 0);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,7 +42,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $this->mock = null;
     }
 
-    protected function mockRequest($method, $path, $params = array(), $return = array('id' => 'myId'))
+    protected function mockRequest($method, $path, $params = [], $return = ['id' => 'myId'])
     {
         $mock = $this->setUpMockRequest();
         $mock->expects($this->once())
@@ -54,7 +54,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
                 $params,
                 false
             )
-            ->willReturn(array(json_encode($return), 200));
+            ->willReturn([json_encode($return), 200]);
     }
 
     protected function setUpMockRequest()
@@ -68,7 +68,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Create a valid test customer.
      */
-    protected static function createTestCustomer(array $attributes = array())
+    protected static function createTestCustomer(array $attributes = [])
     {
         self::authorizeFromEnv();
 
@@ -84,9 +84,9 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $card = Token::create($params, $options = ['payjp_direct_token_generate' => 'true']);
 
         return Customer::create(
-            $attributes + array(
+            $attributes + [
                 'card' => $card
-            )
+            ]
         );
     }
 
@@ -99,7 +99,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $chars = 'abcdefghijklmnopqrstuvwxyz';
         $str = '';
         for ($i = 0; $i < 10; $i++) {
-            $str .= $chars[rand(0, strlen($chars)-1)];
+            $str .= $chars[rand(0, strlen($chars) - 1)];
         }
 
         return $str;
@@ -117,13 +117,13 @@ class TestCase extends \PHPUnit\Framework\TestCase
             $plan = Plan::retrieve($id);
         } catch (Error\InvalidRequest $exception) {
             $plan = Plan::create(
-                array(
+                [
                     'id' => $id,
                     'amount' => 500,
                     'currency' => self::CURRENCY,
                     'interval' => 'month',
                     'name' => 'Gold Test Plan',
-                )
+                ]
             );
         }
         return $plan;

--- a/tests/ThreeDSecureRequestTest.php
+++ b/tests/ThreeDSecureRequestTest.php
@@ -4,7 +4,6 @@ namespace Payjp;
 
 class ThreeDSecureRequestTest extends TestCase
 {
-
     private function managedThreeDSecureRequestResource($id)
     {
         return [
@@ -58,8 +57,8 @@ class ThreeDSecureRequestTest extends TestCase
 
     public function testAll()
     {
-        $expectedThreeDSecureRequestIds = array('tdsr_125192559c91c4011c1ff56f50a', 'tdsr_125192559c91c4011c1ff56f50b');
-        $this->mockRequest('GET', '/v1/three_d_secure_requests', array(), $this->managedThreeDSecureRequestResources($expectedThreeDSecureRequestIds));
+        $expectedThreeDSecureRequestIds = ['tdsr_125192559c91c4011c1ff56f50a', 'tdsr_125192559c91c4011c1ff56f50b'];
+        $this->mockRequest('GET', '/v1/three_d_secure_requests', [], $this->managedThreeDSecureRequestResources($expectedThreeDSecureRequestIds));
         $threeDSecureRequests = ThreeDSecureRequest::all();
         $this->assertSame(count($expectedThreeDSecureRequestIds), $threeDSecureRequests['count']);
         $this->assertCount(count($expectedThreeDSecureRequestIds), $threeDSecureRequests['data']);

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -6,16 +6,16 @@ class UtilTest extends TestCase
 {
     public function testIsList()
     {
-        $list = array(5, 'nstaoush', array());
+        $list = [5, 'nstaoush', []];
         $this->assertTrue(Util\Util::isList($list));
 
-        $notlist = array(5, 'nstaoush', array(), 'bar' => 'baz');
+        $notlist = [5, 'nstaoush', [], 'bar' => 'baz'];
         $this->assertFalse(Util\Util::isList($notlist));
     }
 
     public function testThatPHPHasValueSemanticsForArrays()
     {
-        $original = array('php-arrays' => 'value-semantics');
+        $original = ['php-arrays' => 'value-semantics'];
         $derived = $original;
         $derived['php-arrays'] = 'reference-semantics';
 


### PR DESCRIPTION
This pull request introduces a PHP-CS-Fixer configuration to the project, updates the development dependencies in `composer.json`, and adds a new script for automatically fixing code style issues. These changes aim to improve code quality and streamline development workflows.

### PHP-CS-Fixer Integration:

* Added a new `.php-cs-fixer.dist.php` configuration file to define rules and file paths for PHP-CS-Fixer. The rules include PSR-12 compliance, strict parameter checks, short array syntax, and removal of unused imports.

### Updates to `composer.json`:

* Added `friendsofphp/php-cs-fixer` as a development dependency to enable code style fixing.
* Introduced a new `fix` script to `composer.json` for running PHP-CS-Fixer with the `--allow-risky=yes` option. This script simplifies the process of applying code style fixes.