### PR TITLE
chore: add PHP CS Fixer configuration and update composer scripts

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,15 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__ . '/lib',
+        __DIR__ . '/tests',
+    ])
+    ->append([
+        __FILE__,
+        __DIR__ . '/init.php',
+        __DIR__ . '/build.php',
+    ]);
+
+$config = new PhpCsFixer\Config();
+return $config;

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,10 @@
     }
   },
   "scripts": {
-     "test": [
-       "phpcs --standard=PSR2 -n lib tests *.php",
-       "phpunit"
-     ]
+    "format": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --config=.php-cs-fixer.php lib tests *.php",
+    "test": [
+      "phpcs --standard=PSR2 -n lib tests *.php",
+      "phpunit"
+    ]
   }
 }


### PR DESCRIPTION
This pull request introduces a PHP code formatting tool using PHP-CS-Fixer and adds a new script to the `composer.json` file for automated code formatting. These changes aim to standardize code style and improve developer workflow.

### Code Formatting Setup:
* [`.php-cs-fixer.php`](diffhunk://#diff-ef867390e21235c28e24595707bf636e1cc9cad29cf8ee4ac405c564a9facdf6R1-R15): Added a configuration file for PHP-CS-Fixer, specifying directories (`lib`, `tests`) and files (`init.php`, `build.php`, etc.) to be included in the formatting process.

### Workflow Enhancement:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R36): Added a `format` script to automate code formatting using PHP-CS-Fixer, ensuring consistent code style across the project.